### PR TITLE
New `total_amout` candidate extractor

### DIFF
--- a/utils/preprocess.py
+++ b/utils/preprocess.py
@@ -1,4 +1,4 @@
-""" Module to for preprocessing methods """
+""" Module for preprocessing methods """
 
 from tqdm import tqdm
 import numpy as np


### PR DESCRIPTION
Added new candidate extractor for `total_amount`. This extractor uses `re` module, hence reducing the dependency on NER extractors like CoreNLP, spaCy, e.t.c. Currently the extractor can extract any number which starts with <i>$</I> or has more than 2 digits. Future work:
- Add support for other currency symbols.
- Try other NER extraction models. 